### PR TITLE
pc - add github actions script for frontend-tests

### DIFF
--- a/.github/workflows/frontend-coverage.yml
+++ b/.github/workflows/frontend-coverage.yml
@@ -1,4 +1,4 @@
-name: Frontend Tests and Coverage (JavaScript)
+name: Frontend Coverage (JavaScript/Jest)
 
 on:
   pull_request:

--- a/.github/workflows/frontend-coverage.yml
+++ b/.github/workflows/frontend-coverage.yml
@@ -22,4 +22,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
         working-directory: ./frontend
-    
+      - run: npm run coverage
+        working-directory: ./frontend
+      - name: Upload to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash)
+        working-directory: ./frontend
+     

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,4 +1,4 @@
-name: Frontend Tests and Coverage (JavaScript)
+name: Frontend Tests (JavaScript/Jest)
 
 on:
   pull_request:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,32 @@
+name: Frontend Tests and Coverage (JavaScript)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [17.x]
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          fetch-depth: 2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: ./frontend
+      - run: npm run coverage
+        working-directory: ./frontend
+      - name: Upload to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash)
+        working-directory: ./frontend
+     

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -22,4 +22,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
         working-directory: ./frontend
+      - run: npm test
+        working-directory: ./frontend
     

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "coverage": "react-scripts test --coverage --watchAll=false"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
# Overview

In this PR, we add two GitHub actions scripts:
* frontend-tests  runs the basic frontend tests
* frontend-coverage  computes code coverage for the frontend tests and 
  uploads to Codecov



