### PR TITLE
pc - try adding jeykll

### DIFF
--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -28,7 +28,7 @@ jobs:
           token: ${{ secrets.DOCS_TOKEN }}
           branch: main # The branch the action should deploy to.
           folder: frontend/docs-qa-index 
-          clean: true 
+          clean: false 
           target-folder: docs
       - name: Generate .md file to add to branch collection
         working-directory: ./frontend

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -41,6 +41,7 @@ jobs:
           echo "---" >> $FILENAME
           echo "name: ${{ github.head_ref }}" >> $FILENAME
           echo "actor: ${{ github.actor}}" >> $FILENAME
+          echo "pull_request_url: ${{ github.event.pull_request.url}}" >> $FILENAME
           echo "---" >> $FILENAME
       # - name: Deploy (branch-name).md file to branch collection 🚀
       #   uses: JamesIves/github-pages-deploy-action@4.2.0

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -16,6 +16,7 @@ jobs:
         working-directory: ./frontend/docs-qa-index
         run: | 
           echo "repo_name: ${{github.repository}}" >> _config.yml
+          echo "owner: ${{ github.repository_owner }}" >> _config.yml
       - name: Deploy index.md and jekyll files for docs-qa site 🚀
         uses: JamesIves/github-pages-deploy-action@4.2.0
         with:

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
-      - name: Deploy index.md for docs-qa site 🚀
+      - name: Deploy index.md and jekyll files for docs-qa site 🚀
         uses: JamesIves/github-pages-deploy-action@4.2.0
         with:
           repository-name: ${{ github.repository }}-docs-qa
@@ -21,24 +21,26 @@ jobs:
           folder: frontend/docs-qa-index 
           clean: true 
           target-folder: docs
-      - name: Generate Markdown file of links to branches
-        working-directory: ./frontend/scripts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate .md file to add to branch collection
+        working-directory: ./frontend
         run: | 
-          gh api repos/ucsb-cs156-w22/demo-cra-customized/branches > branches.json
-          mkdir -p ../storybook-qa-list
-          /bin/rm -f ../storybook-qa-list/index.md
-          node list-branches.mjs > ../storybook-qa-list/index.md
-      - name: Deploy 🚀
+          BRANCH_DIR=_branches.tmp
+          mkdir -p $BRANCH_DIR
+          FILENAME=${BRANCH_DIR}/${{github.head_ref }}.md
+          rm -f $FILENAME
+          touch $FILENAME
+          echo "---" >> $FILENAME
+          echo "name: ${{ github.head_ref }}" >> $FILENAME
+          echo "---" >> $FILENAME
+      - name: Deploy (branch-name).md file to branch collection 🚀
         uses: JamesIves/github-pages-deploy-action@4.2.0
         with:
           repository-name: ${{ github.repository }}-docs-qa
           token: ${{ secrets.DOCS_TOKEN }}
           branch: main # The branch the action should deploy to.
-          folder: frontend/storybook-qa-list # The folder that the build-storybook script generates files.
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: docs/storybook-qa-list/
+          folder: frontend/_branches.tmp # The folder that the build-storybook script generates files.
+          clean: false # Automatically remove deleted files from the deploy branch
+          target-folder: docs/_branches
       - name: Install and Build 🔧
         working-directory: ./frontend
         run: | # Install npm packages and build the Storybook files

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -12,6 +12,10 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
+      - name: Append name of site to _config.yml
+        working-directory: ./frontend/docs-qa-index
+        run: | 
+          echo "repo_name: ${{github.repository}}" >> $FILENAME
       - name: Deploy index.md and jekyll files for docs-qa site 🚀
         uses: JamesIves/github-pages-deploy-action@4.2.0
         with:

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -40,6 +40,7 @@ jobs:
           touch $FILENAME
           echo "---" >> $FILENAME
           echo "name: ${{ github.head_ref }}" >> $FILENAME
+          echo "actor: ${{ github.actor}}" >> $FILENAME
           echo "---" >> $FILENAME
       # - name: Deploy (branch-name).md file to branch collection 🚀
       #   uses: JamesIves/github-pages-deploy-action@4.2.0
@@ -50,7 +51,7 @@ jobs:
       #     folder: frontend/_branches.tmp # The folder that the build-storybook script generates files.
       #     clean: false # Automatically remove deleted files from the deploy branch
       #     target-folder: docs/_branches
-      - name: Pushes test file
+      - name: Pushes branch
         uses: dmnemec/copy_file_to_another_repo_action@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.DOCS_TOKEN }}

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Append name of site to _config.yml
         working-directory: ./frontend/docs-qa-index
         run: | 
-          echo "repo_name: ${{github.repository}}" >> $FILENAME
+          echo "repo_name: ${{github.repository}}" >> _config.yml
       - name: Deploy index.md and jekyll files for docs-qa site 🚀
         uses: JamesIves/github-pages-deploy-action@4.2.0
         with:

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -15,8 +15,12 @@ jobs:
       - name: Append name of site to _config.yml
         working-directory: ./frontend/docs-qa-index
         run: | 
-          echo "repo_name: ${{github.repository}}" >> _config.yml
-          echo "owner: ${{ github.repository_owner }}" >> _config.yml
+          OWNER_PLUS_REPOSITORY=${{github.repository}}
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          echo "repo: ${OWNER_PLUS_REPOSITORY}" >> _config.yml
+          echo "owner: ${OWNER}" >> _config.yml
+          echo "repo_name: ${REPOSITORY}" >> _config.yml
       - name: Deploy index.md and jekyll files for docs-qa site 🚀
         uses: JamesIves/github-pages-deploy-action@4.2.0
         with:

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -59,6 +59,8 @@ jobs:
           destination_repo: ${{ github.repository }}-docs-qa
           destination_folder: 'docs/_branches'
           commit_message: 'Add branch ${{ github.head_ref }} to docs-qa repo'
+          user_email: phtcon@ucsb.edu
+          user_name: "Phill Conrad, UCSB CS machine user"
       - name: Install and Build 🔧
         working-directory: ./frontend
         run: | # Install npm packages and build the Storybook files

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -41,7 +41,8 @@ jobs:
           echo "---" >> $FILENAME
           echo "name: ${{ github.head_ref }}" >> $FILENAME
           echo "actor: ${{ github.actor}}" >> $FILENAME
-          echo "pull_request_url: ${{ github.event.pull_request.url}}" >> $FILENAME
+          echo "pull_request_url: ${{ github.event.pull_request.html_url}}" >> $FILENAME
+          echo "pull_request_num: ${{ github.event.pull_request.number}}" >> $FILENAME
           echo "---" >> $FILENAME
       # - name: Deploy (branch-name).md file to branch collection 🚀
       #   uses: JamesIves/github-pages-deploy-action@4.2.0

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -41,15 +41,24 @@ jobs:
           echo "---" >> $FILENAME
           echo "name: ${{ github.head_ref }}" >> $FILENAME
           echo "---" >> $FILENAME
-      - name: Deploy (branch-name).md file to branch collection 🚀
-        uses: JamesIves/github-pages-deploy-action@4.2.0
+      # - name: Deploy (branch-name).md file to branch collection 🚀
+      #   uses: JamesIves/github-pages-deploy-action@4.2.0
+      #   with:
+      #     repository-name: ${{ github.repository }}-docs-qa
+      #     token: ${{ secrets.DOCS_TOKEN }}
+      #     branch: main # The branch the action should deploy to.
+      #     folder: frontend/_branches.tmp # The folder that the build-storybook script generates files.
+      #     clean: false # Automatically remove deleted files from the deploy branch
+      #     target-folder: docs/_branches
+      - name: Pushes test file
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.DOCS_TOKEN }}
         with:
-          repository-name: ${{ github.repository }}-docs-qa
-          token: ${{ secrets.DOCS_TOKEN }}
-          branch: main # The branch the action should deploy to.
-          folder: frontend/_branches.tmp # The folder that the build-storybook script generates files.
-          clean: false # Automatically remove deleted files from the deploy branch
-          target-folder: docs/_branches
+          source_file: 'frontend/_branches.tmp/${{github.head_ref }}.md'
+          destination_repo: ${{ github.repository }}-docs-qa
+          destination_folder: 'docs/_branches'
+          commit_message: 'Add branch ${{ github.head_ref }} to docs-qa repo'
       - name: Install and Build 🔧
         working-directory: ./frontend
         run: | # Install npm packages and build the Storybook files

--- a/frontend/docs-qa-index/_config.yml
+++ b/frontend/docs-qa-index/_config.yml
@@ -7,6 +7,8 @@ description: >- # this means to ignore newlines until "baseurl:"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
+repo_name: "This-should-be-overridden-by-github-actions-script"
+
 # Build settings
 theme: minima
 plugins:
@@ -16,3 +18,5 @@ collections:
   branches:
     output: true
     permalink: /branches/:path/
+
+repo_name: "This-should-be-overridden-by-github-actions-script"

--- a/frontend/docs-qa-index/_config.yml
+++ b/frontend/docs-qa-index/_config.yml
@@ -1,9 +1,9 @@
 
-title: Your awesome title
+title: QA Site for Documentation
 description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  When reviewing a PR for this repo, you can see what the documentation,
+  e.g. the storybook, will look like when published for the branches
+  named above.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
@@ -11,7 +11,6 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 theme: minima
 plugins:
   - jekyll-feed
-
 
 collections:
   branches:

--- a/frontend/docs-qa-index/_config.yml
+++ b/frontend/docs-qa-index/_config.yml
@@ -1,0 +1,19 @@
+
+title: Your awesome title
+description: >- # this means to ignore newlines until "baseurl:"
+  Write an awesome description for your new site here. You can edit this
+  line in _config.yml. It will appear in your document head meta (for
+  Google search results) and in your feed.xml site description.
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+
+# Build settings
+theme: minima
+plugins:
+  - jekyll-feed
+
+
+collections:
+  branches:
+    output: true
+    permalink: /branches/:path/

--- a/frontend/docs-qa-index/_layouts/default.html
+++ b/frontend/docs-qa-index/_layouts/default.html
@@ -6,10 +6,7 @@
     <link rel="stylesheet" href="/{{site.repo_name}}/css/style.css">
   </head>
   <body>
-    <nav>
-      <a href="/{{site.repo_name}}">Home</a>
-    </nav>
-    <h1>{{ page.title }}</h1>
+    <h1>{{site.repo_name}}-qa-docs</h1>
     <section>
       {{ content }}
     </section>

--- a/frontend/docs-qa-index/_layouts/default.html
+++ b/frontend/docs-qa-index/_layouts/default.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ page.title }}</title>
+    <link rel="stylesheet" href="/{{site.repo_name}}/css/style.css">
+  </head>
+  <body>
+    <nav>
+      <a href="/{{site.repo_name}}">Home</a>
+    </nav>
+    <h1>{{ page.title }}</h1>
+    <section>
+      {{ content }}
+    </section>
+    <footer>
+    </footer>
+  </body>
+</html>

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -35,7 +35,7 @@ tr:nth-child(even) {background-color: #f2f2f2;}
 <tr>
 <td>{{b.name}}</td>
 <td>{{b.actor}}</td>
-<td>{{b.pull_request_url}}</td>
+<td><a href="{{b.pull_request_url}}">PR {{b.}}</a></td>
 <td><a href="storybook-qa/{{b.name}}">storybook</a></td>
 </tr>
 {% endfor %}

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -13,6 +13,14 @@
 
 ## Branches
 
+<style>
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+tr:nth-child(even) {background-color: #f2f2f2;}
+</style>
+
 <table>
 <thead>
 <tr>

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -3,8 +3,8 @@
 
 ## Repos
 
-* Source Repo: <https://github.com/{{site.repo_name}}>
-* Production Docs Repo: <https://github.com/{{site.repo_name}}-docs>
+* Source Repo: <https://github.com/{{site.repo}}>
+* Production Docs Repo: <https://github.com/{{site.repo}}-docs>
 
 * QA Docs Repo: <https://github.com/{{site.repo}}-docs-qa>
 

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -15,11 +15,21 @@
 
 <table>
 <thead>
-<tr><th>Branch</th><th>Who Pushed It</th><th>Storybook</th></tr>
-<thead>
+<tr>
+<th>Branch</th>
+<th>Who Pushed It</th>
+<th>PR</th>
+<th>Storybook</th>
+</tr>
+</thead>
 <tbody>
 {% for b in site.branches %}
-<tr><td>{{b.name}}</td><td>{{b.actor}}</td><td><a href="storybook-qa/{{b.name}}">storybook</a></td></tr>
+<tr>
+<td>{{b.name}}</td>
+<td>{{b.actor}}</td>
+<td>{{b.pull_request_url}}</td>
+<td><a href="storybook-qa/{{b.name}}">storybook</a></td>
+</tr>
 {% endfor %}
 </tbody>
 </table>

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -2,8 +2,12 @@
 ---
 
 * Owner/Organization: {{site.owner}}
+* Repo Name: {{site.repo_name}}
+* Repo Name: {{site.repo}}
 * Source Repo: <https://github.com/{{site.repo_name}}>
-* Production Docs: <https://github.com/{{site.repo_name}}-docs>
+* Production Docs Repo: <https://github.com/{{site.repo_name}}-docs>
+* Production Docs: <https://{{site.owner}}.github.io/{{site.repo_name}}-docs>
+* QA Docs Repo: <https://github.com/{{site.repo_name}}-docs-qa>
 
 
 # Branches

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -1,10 +1,9 @@
 ---
 ---
 
-# QA Site for Documentation 
-
-* Source Repo: <https://github.com/ucsb-cs156-w22/{{site.repo_name}}>
-* Production Docs: <https://github.com/ucsb-cs156-w22/{{site.repo_name}}-docs>
+* Owner/Organization: {{site.owner}}
+* Source Repo: <https://github.com/{{site.repo_name}}>
+* Production Docs: <https://github.com/{{site.repo_name}}-docs>
 
 
 # Branches

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -1,16 +1,18 @@
 ---
 ---
 
-* Owner/Organization: {{site.owner}}
-* Repo Name: {{site.repo_name}}
-* Repo Name: {{site.repo}}
+## Repos
+
 * Source Repo: <https://github.com/{{site.repo_name}}>
 * Production Docs Repo: <https://github.com/{{site.repo_name}}-docs>
-* Production Docs: <https://{{site.owner}}.github.io/{{site.repo_name}}-docs>
-* QA Docs Repo: <https://github.com/{{site.repo_name}}-docs-qa>
 
+* QA Docs Repo: <https://github.com/{{site.repo}}-docs-qa>
 
-# Branches
+## Production Documentation
+
+* <https://{{site.owner}}.github.io/{{site.repo_name}}-docs>
+
+## Branches
 
 {% for b in site.branches %}
 * [{{ b.name }}](storybook-qa/{{b.name}})

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -3,16 +3,14 @@
 
 # QA Site for Documentation 
 
-* Source Repo: <https://github.com/ucsb-cs156-w22/demo-cra-customized>
-* Production Docs: <https://github.com/ucsb-cs156-w22/demo-cra-customized-docs>
+* Source Repo: <https://github.com/ucsb-cs156-w22/{{site.repo_name}}>
+* Production Docs: <https://github.com/ucsb-cs156-w22/{{site.repo_name}}-docs>
 
-* [Storybook QA Branches](storybook-qa-list/)
 
-# Branch collection
+# Branches
 
 {% for b in site.branches %}
 * [{{ b.name }}](storybook-qa/{{b.name}})
 {% endfor %}
 
 
-# This is after the branch collection

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -5,7 +5,6 @@
 
 * Source Repo: <https://github.com/{{site.repo}}>
 * Production Docs Repo: <https://github.com/{{site.repo}}-docs>
-
 * QA Docs Repo: <https://github.com/{{site.repo}}-docs-qa>
 
 ## Production Documentation
@@ -14,8 +13,10 @@
 
 ## Branches
 
+| Branch | Who Pushed It | Storybook |
+|--------|---------------|-----------|
 {% for b in site.branches %}
-* [{{ b.name }}](storybook-qa/{{b.name}})
+|{{b.name}}| {{b.actor}}| [storybook](storybook-qa/{{b.name}})|
 {% endfor %}
 
 

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -1,6 +1,18 @@
+---
+---
+
 # QA Site for Documentation 
 
 * Source Repo: <https://github.com/ucsb-cs156-w22/demo-cra-customized>
 * Production Docs: <https://github.com/ucsb-cs156-w22/demo-cra-customized-docs>
 
 * [Storybook QA Branches](storybook-qa-list/)
+
+# Branch collection
+
+{% for b in site.branches %}
+* [{{ b.name }}](storybook-qa/{{b.name}})
+{% endfor %}
+
+
+# This is after the branch collection

--- a/frontend/docs-qa-index/index.md
+++ b/frontend/docs-qa-index/index.md
@@ -13,10 +13,14 @@
 
 ## Branches
 
-| Branch | Who Pushed It | Storybook |
-|--------|---------------|-----------|
+<table>
+<thead>
+<tr><th>Branch</th><th>Who Pushed It</th><th>Storybook</th></tr>
+<thead>
+<tbody>
 {% for b in site.branches %}
-|{{b.name}}| {{b.actor}}| [storybook](storybook-qa/{{b.name}})|
+<tr><td>{{b.name}}</td><td>{{b.actor}}</td><td><a href="storybook-qa/{{b.name}}">storybook</a></td></tr>
 {% endfor %}
-
+</tbody>
+</table>
 


### PR DESCRIPTION
# Overview

In this PR, we add Jekyll for managing a collection of branches in the docs-qa site.

The purpose is to allow documentations sites for multiple branches to co-exist within a single GitHub pages repo, so that it can be reviewed before a PR is merged.

