### PR TITLE
pc - for demo purposes only, add a cereal menu to the navbar

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import ActionOnePage from "main/pages/actions/ActionOne";
 import ActionTwoPage from "main/pages/actions/ActionTwo";
 import ActionThreePage from "main/pages/actions/ActionThree";
 import ActionFourPage from "main/pages/actions/ActionFour";
+import CerealPage from "main/pages/CerealPage"
 
 import "bootstrap/dist/css/bootstrap.css";
 
@@ -20,6 +21,10 @@ function App() {
           <Route path="/action/two" element={<ActionTwoPage />} />
           <Route path="/action/three" element={<ActionThreePage />} />
           <Route path="/action/four" element={<ActionFourPage />} />
+          <Route path="/cereal/cp" element={<CerealPage name="Cocoa Puffs" />} />
+          <Route path="/cereal/fl" element={<CerealPage name="Froot Loops" />} />
+          <Route path="/cereal/cc" element={<CerealPage name="Cap'n Crunch" />} />
+          <Route path="/cereal/oatmeal" element={<CerealPage name="Oatmeal" />} />
         </Routes>
       </BrowserRouter>
   );

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -16,6 +16,13 @@ export default function AppNavbar() {
               <NavDropdown.Divider />
               <NavDropdown.Item href="/action/four">Separated link</NavDropdown.Item>
             </NavDropdown>
+            <NavDropdown title="Cereals" id="basic-nav-dropdown">
+              <NavDropdown.Item href="/cereal/cp">Cocoa Puffs</NavDropdown.Item>
+              <NavDropdown.Item href="/cereal/fl">Froot Loops</NavDropdown.Item>
+              <NavDropdown.Item href="/cereal/cc">Cap'n Crunch</NavDropdown.Item>
+              <NavDropdown.Divider />
+              <NavDropdown.Item href="/cereal/oatmeal">Oatmeal</NavDropdown.Item>
+            </NavDropdown>
           </Nav>
         </Navbar.Collapse>
       </Container>

--- a/frontend/src/main/pages/CerealPage.js
+++ b/frontend/src/main/pages/CerealPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout";
+
+export default function CerealPage({name}) {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Cereal: { name } </h1>
+        <p>
+          If we added another prop for the text about the cereal, we could customize this part.
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}


### PR DESCRIPTION
# Overview

This PR adds a cereal menu to the navbar, just for illustration purposes. 

We probably won't merge it, but we'll pretend for now that we are going to, so we'll go through all the stages right up to code review.

# Before

<img width="676" alt="image" src="https://user-images.githubusercontent.com/1119017/151248468-9f2694ee-faa4-416c-9743-3023405dc89d.png">


# After

<img width="600" alt="image" src="https://user-images.githubusercontent.com/1119017/151248626-15e00551-5458-495e-81aa-b4208dac5ffe.png">

